### PR TITLE
Update text mining template documentation

### DIFF
--- a/content/templates/textmining/_index.en.md
+++ b/content/templates/textmining/_index.en.md
@@ -19,22 +19,22 @@ create_dir: true
 ---
 ## Detailed Description
 
-The Interactive Text Analysis Dashboard template (`text_mining`) summarizes the chief complaint text and diagnosis codes as part of an initial description of the content of these fields in *existing* syndromes or categories.
+The Interactive Text Analysis Dashboard template (`text_mining`) summarizes the chief complaint text and discharge diagnosis codes as part of an initial description of the content of these fields. Drop-down menus allow users to select from *existing* ESSENCE syndrome definitions, including CCDD categories, syndromes, and subsyndromes. Users can also input a custom query of the CCDD field or the API URL for complex queries that search multiple fields. 
 
-The data source used in this template is the Chief Complaint Query Validation (CCQV) data source in NSSP-ESSENCE, which includes the chief complaint and discharge diagnosis fields, and does not include facility location, patient location, or other demographic information. This data source was created with the Syndromic Community of Practice (CoP) so that users can test and create new syndrome categories using a large corpus of chief complaint and diagnosis code data that includes more variation than would be present in any one site.  Some sites have opted out of contributing their data to the Query Validation data source, including Arizona, Idaho, Illinois, Marion County, Indiana, Massachusetts, North Dakota, and Ohio.
+By default, this template uses the Chief Complaint Query Validation (CCQV) data source in NSSP-ESSENCE, which includes the chief complaint and discharge diagnosis fields and does not include facility location, patient location, or other demographic information. This data source was created in collaboration with the NSSP Community of Practice (CoP). Users can test and create new syndrome categories using a large corpus of chief complaint and diagnosis code data that has more variation than would be present in any one site.  Some sites have opted out and do not contribute data to the Query Validation data source, including Arizona; Idaho; Illinois; Marion County, Indiana; Massachusetts; North Dakota; and Ohio. To accomodate site-level users, the full data details (facility location) data source can be selected so that data are pulled at the individual state-level. **Note: The API URL for the full details data source limits to CCQV fields only.** 
 
-The visualizations in this template include total weekly volume of encounters, the 200 most frequent n-gram frequencies of chief complaint terms and discharge diagnosis codes, term co-occurrence network graphs for the ChiefComplaintParsed and CCDD fields, a chief complaint term correlation network graph, and n-grams with significant increases or decreases in occurrence over time. Potential clusters or groupings of terms are visualized by node color and can be selected from the "Select by group" drop down menu.
+The visualizations in this template include total weekly volume of encounters, the 200 most frequent n-gram frequencies of chief complaint terms and discharge diagnosis codes, term co-occurrence network graphs for the ChiefComplaintParsed and CCDD fields, a chief complaint term correlation network graph, and n-grams with significant increases or decreases in occurrence over time. Potential clusters or groupings of terms are visualized by node color in term co-occurrence network graphs and can be selected from the "Select by group" drop-down menu. Clusters are determined by the Louvain algorithm, an unsupervised method to detect communities in networks by maximizing modularity. 
 
-All interactive widgets were produced with the [plotly](https://plotly.com/r/) and [visNetwork](https://cran.r-project.org/web/packages/visNetwork/vignettes/Introduction-to-visNetwork.html) packages which provide hovering functionality such as displaying data point values, ICD-10 code descriptions, and co-occurrence frequencies.
+Interactive widgets were produced with the [plotly](https://plotly.com/r/) and [visNetwork](https://cran.r-project.org/web/packages/visNetwork/vignettes/Introduction-to-visNetwork.html) packages. These packages provide hovering functionality such as displaying data point values, ICD-10 code descriptions, and co-occurrence frequencies.
 
 ---
 ## User Inputs
 
-* AMC username and password (securely encrypted)
-* Start and end date of query
+* Access and Management Center (AMC) username and password (securely encrypted)
+* Query start and end dates
 * Has been Emergency: TRUE/FALSE option for limiting to emergency department visits 
-* Data source: options include the Chief Complaint Query Validation (CCQV) data source or Facility Location (Full Details)
-* Syndrome definition: CCDD Category, Subsyndrome, or Syndrome.
+* Data source: options include the Chief Complaint Query Validation (CCQV) data source or Facility Location \[Full Details\]
+* Syndrome definition: CCDD category, subsyndrome, or syndrome.
 
 ---
 ## Output


### PR DESCRIPTION
Update text mining template documentation to summarize the new input parameters (i.e., custom CCDD and complex query API URL, syndrome definitions, etc. ). Add description of how node colors are determined in the co-occurrence network graph. Highlight that site-level users can select the full details data source to pull in data for their own state.